### PR TITLE
[WIP] Update the ADBackend information when updating from pre 6.0 (#580)

### DIFF
--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADBackendStoreTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADBackendStoreTest.cs
@@ -69,7 +69,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
         [TestMethod]
         public void ItemCanBeAddedToStoreAndRetrievedViaDisk()
         {
-            _store.Add(new StorableClass { Name = "Hello" });
+            _store.Add(new StorableClass { Name = "Hello", Id = Guid.NewGuid() });
 
             var loadStore = MakeStore();
             var retrieved = loadStore.Single();
@@ -161,6 +161,11 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
             public Guid Id { get; set; }
             public string Name { get; set; }
             public string DisplayName { get { return Name; } }
+
+            public StorableClass()
+            {
+                Id = Guid.NewGuid();
+            }
         }
     }
 }

--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADPermissionServiceTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADPermissionServiceTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Models;
 using Bonobo.Git.Server.Security;
@@ -38,7 +39,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
 
         protected override TeamModel CreateTeam()
         {
-            var newTeam = new TeamModel { Name = "Team1" };
+            var newTeam = new TeamModel { Name = "Team1", Id = Guid.NewGuid() };
             newTeam.Members = new UserModel[0];
             ADBackend.Instance.Teams.Add(newTeam);
             return newTeam;

--- a/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADRepositoryRepositoryServiceTest.cs
+++ b/Bonobo.Git.Server.Test/MembershipTests/ADTests/ADRepositoryRepositoryServiceTest.cs
@@ -30,7 +30,7 @@ namespace Bonobo.Git.Server.Test.MembershipTests.ADTests
 
         protected override TeamModel AddTeam()
         {
-            var newTeam = new TeamModel { Name = "Team1"};
+            var newTeam = new TeamModel { Name = "Team1", Id = Guid.NewGuid()};
             ADBackend.Instance.Teams.Add(newTeam);
             return newTeam;
         }

--- a/Bonobo.Git.Server/Bonobo.Git.Server.csproj
+++ b/Bonobo.Git.Server/Bonobo.Git.Server.csproj
@@ -127,6 +127,7 @@
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
@@ -258,6 +259,8 @@
     <Compile Include="Data\ADTeamRepository.cs" />
     <Compile Include="Data\DatabaseResetManager.cs" />
     <Compile Include="Data\INameProperty.cs" />
+    <Compile Include="Data\Update\ADBackend\ADBackendPre6.0.0Models.cs" />
+    <Compile Include="Data\Update\ADBackend\UpdateADBackend.cs" />
     <Compile Include="Data\Update\Sqlite\AddGroup.cs" />
     <Compile Include="Data\Update\Sqlite\AddGuidColumn.cs" />
     <Compile Include="Data\Update\Sqlite\AddRepoPushColumn.cs" />

--- a/Bonobo.Git.Server/Data/ADBackend.cs
+++ b/Bonobo.Git.Server/Data/ADBackend.cs
@@ -43,9 +43,22 @@ namespace Bonobo.Git.Server.Data
 
         public static void ResetSingletonForTesting()
         {
+            ResetSingletonWithoutAutomaticUpdate();
+        }
+
+        public static void ResetSingletonWithoutAutomaticUpdate()
+        {
             lock (instanceLock)
             {
                 instance = new ADBackend(false);
+            }
+        }
+
+        public static void ResetSingletonWithAutomaticUpdate()
+        {
+            lock (instanceLock)
+            {
+                instance = new ADBackend(true);
             }
         }
 

--- a/Bonobo.Git.Server/Data/Update/ADBackend/ADBackendPre6.0.0Models.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/ADBackendPre6.0.0Models.cs
@@ -1,0 +1,85 @@
+﻿
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+
+namespace Bonobo.Git.Server.Data.Update.Pre600ADBackend
+{
+    public interface Pre600INameProperty
+    {
+        string Name { get; }
+    }
+
+    // These models were used pre 6.0.0
+    public class Pre600RoleModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string[] Members { get; set; }
+    }
+
+    public class Pre600UserModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string GivenName { get; set; }
+        public string Surname { get; set; }
+        public string Email { get; set; }
+
+        public string DisplayName
+        {
+            get
+            {
+                return String.Format("{0} {1}", GivenName, Surname);
+            }
+        }
+    }
+
+    public class Pre600TeamModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string[] Members { get; set; }
+    }
+
+
+    public class Pre600RepositoryModel : Pre600INameProperty
+    {
+        public string Name { get; set; }
+        public string Group { get; set; }
+        public string Description { get; set; }
+        public bool AnonymousAccess { get; set; }
+        public string[] Users { get; set; }
+        public string[] Administrators { get; set; }
+        public string[] Teams { get; set; }
+        public bool AuditPushUser { get; set; }
+        public byte[] Logo { get; set; }
+        public bool RemoveLogo { get; set; }
+    }
+
+    public class Pre600Functions
+    {
+        public static ConcurrentDictionary<string, T> LoadContent<T>(string storagePath) where T : Pre600INameProperty
+        {
+            ConcurrentDictionary<string, T> result = new ConcurrentDictionary<string, T>();
+
+            if (!Directory.Exists(storagePath))
+            {
+                Directory.CreateDirectory(storagePath);
+            }
+
+            foreach (string filename in Directory.EnumerateFileSystemEntries(storagePath, "*.json"))
+            {
+                try
+                {
+                    T item = JsonConvert.DeserializeObject<T>(File.ReadAllText(filename));
+                    result.TryAdd(item.Name, item);
+                }
+                catch
+                {
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
+++ b/Bonobo.Git.Server/Data/Update/ADBackend/UpdateADBackend.cs
@@ -1,0 +1,248 @@
+﻿using Bonobo.Git.Server.Data.Update.Pre600ADBackend;
+using System.IO;
+using Bonobo.Git.Server.Helpers;
+using System.Collections.Generic;
+using System.DirectoryServices.AccountManagement;
+using Bonobo.Git.Server.Configuration;
+using System;
+using System.Threading;
+using System.Linq;
+using Bonobo.Git.Server.Data;
+using Microsoft.VisualBasic.FileIO;
+using Newtonsoft.Json;
+
+namespace Bonobo.Git.Server.Data.Update.ADBackendUpdate
+{
+    public class Pre600UpdateTo600
+    {
+        // Before 6.0.0 the mapping was done via the name property. After that the Guid is used.
+        public static void UpdateADBackend()
+        {
+            // Make a copy of the current backendfolder if it exists, so we can use the modern models for saving
+            // it all to the correct location directly
+            var backendDirectory = PathEncoder.GetRootPath(ActiveDirectorySettings.BackendPath);
+            var backupDirectory = PathEncoder.GetRootPath(ActiveDirectorySettings.BackendPath + "_pre6.0.0_" + DateTime.UtcNow.ToString("yyyyMMdd_HHmmss"));
+            if (Directory.Exists(backendDirectory) && BackEndNeedsUpgrade(backendDirectory))
+            {
+                MakeBackupOfBackendDirectory(backendDirectory, backupDirectory);
+
+                // We must create one that will not automatically update the items while we update them
+                ADBackend.ResetSingletonWithoutAutomaticUpdate();
+
+                var newUsers = UpdateUsers(Path.Combine(backupDirectory, "Users"));
+                var newTeams = UpdateTeams(Path.Combine(backupDirectory, "Teams"), newUsers);
+                UpdateRoles(Path.Combine(backupDirectory, "Roles"), newUsers);
+                UpdateRepos(Path.Combine(backupDirectory, "Repos"), newUsers, newTeams);
+
+                // We are done, enable automatic update again.
+                ADBackend.ResetSingletonWithAutomaticUpdate();
+            }
+        }
+
+        /// <summary>
+        /// Check if the backend needs upgrading - try to load all the .json files - if they load OK and have GUID ids, then 
+        /// we don't need to load
+        /// </summary>
+        /// <param name="dir"></param>
+        /// <returns></returns>
+        private static bool BackEndNeedsUpgrade(string dir)
+        {
+            if (BackendSubDirectoryNeedsUpdating<Models.RoleModel>(dir, "Roles"))
+            {
+                return true;
+            }
+            if (BackendSubDirectoryNeedsUpdating<Models.UserModel>(dir, "Users"))
+            {
+                return true;
+            }
+            if (BackendSubDirectoryNeedsUpdating<Models.TeamModel>(dir, "Teams"))
+            {
+                return true;
+            }
+            if (BackendSubDirectoryNeedsUpdating<Models.RepositoryModel>(dir, "Repos"))
+            {
+                return true;
+            }
+            return false;
+        }
+
+
+        /// <summary>
+        /// Try all the json files in one subdirectory
+        /// </summary>
+        private static bool BackendSubDirectoryNeedsUpdating<T>(string backendDirectory, string subdirectory) where T : INameProperty
+        {
+            var directory = Path.Combine(backendDirectory, subdirectory);
+            foreach (var jsonfile in new DirectoryInfo(directory).EnumerateFiles("*.json"))
+            {
+                // try to load with the modern models, if it succeeds we don't need to update
+                try
+                {
+                    var x = JsonConvert.DeserializeObject<T>(File.ReadAllText(jsonfile.FullName));
+                    if (x.Id == Guid.Empty)
+                    {
+                        // No GUID - we need to convert
+                        return true;
+                    }
+                    break;
+                }
+                catch (JsonSerializationException)
+                {
+                    // We must convert...
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static void MakeBackupOfBackendDirectory(string backendDirectory, string backupDirectory)
+        {
+            FileSystem.CopyDirectory(backendDirectory, backupDirectory);
+            int attemptsRemaining = 5;
+            while (attemptsRemaining-- > 0)
+            {
+                try
+                {
+                    Directory.Delete(backendDirectory, true);
+                    return;
+                }
+                catch (IOException) // System.IO.IOException: The directory is not empty
+                {
+                    // Normally it's only the top most dir that fails to delete for some reason (usually because Explorer is holding a handle to stuff)...
+                    // If any json files are left we have a problem, if only folders are left
+                    // we can let it update without any problems. Leaving the old json files
+                    // means they would get loaded next run and crash the server.
+                    if (attemptsRemaining == 0 && Directory.EnumerateFiles(backendDirectory, "*.json").Any())
+                    {
+                        throw;
+                    }
+                    Thread.Sleep(1000);
+                }
+            }
+        }
+
+        private static void UpdateRepos(string dir, Dictionary<string, Models.UserModel> users, Dictionary<string, Models.TeamModel> teams)
+        {
+            var repos = Pre600Functions.LoadContent<Pre600RepositoryModel>(dir);
+            foreach(var repoitem in repos)
+            {
+                var repo = repoitem.Value;
+                var newrepo = new Models.RepositoryModel();
+                newrepo.Id = Guid.NewGuid();
+                newrepo.Name = repo.Name;
+                newrepo.Group = repo.Group;
+                newrepo.Description = repo.Description;
+                newrepo.AnonymousAccess = repo.AnonymousAccess;
+                newrepo.AuditPushUser = repo.AuditPushUser;
+                newrepo.Logo = repo.Logo;
+                newrepo.RemoveLogo = repo.RemoveLogo;
+
+                var list = new List<Models.UserModel>();
+                foreach (var user in repo.Users)
+                {
+                    list.Add(users[user]);
+                }
+                newrepo.Users = list.ToArray();
+
+                list.Clear();
+                foreach(var admins in repo.Administrators)
+                {
+                    list.Add(users[admins]);
+                }
+                newrepo.Administrators = list.ToArray();
+
+                var newteams = new List<Models.TeamModel>();
+                foreach(var team in repo.Teams)
+                {
+                    newteams.Add(teams[team]);
+                }
+                newrepo.Teams = newteams.ToArray();
+
+                ADBackend.Instance.Repositories.Add(newrepo);
+            }
+        }
+
+        private static void UpdateRoles(string dir, Dictionary<string, Models.UserModel> users)
+        {
+            var roles = Pre600Functions.LoadContent<Pre600RoleModel>(dir);
+            foreach(var roleitem in roles)
+            {
+                var role = roleitem.Value;
+                var newrole = new Models.RoleModel();
+                newrole.Name = role.Name;
+
+                newrole.Id = Guid.NewGuid();
+                var members = new List<Guid>();
+                foreach (var memberName in role.Members)
+                {
+                    Models.UserModel user;
+                    if (users.TryGetValue(memberName, out user))
+                    {
+                        members.Add(user.Id);
+                    }
+                }
+                newrole.Members = members.ToArray();
+            }
+        }
+
+        private static Dictionary<string, Models.TeamModel> UpdateTeams(string dir, Dictionary<string, Models.UserModel> users)
+        {
+            var teams = Pre600Functions.LoadContent<Pre600TeamModel>(dir);
+            var newTeams = new Dictionary<string, Models.TeamModel>();
+            foreach(var teamitem in teams)
+            {
+                var team = teamitem.Value;
+                var newteam = new Models.TeamModel();
+                newteam.Name = team.Name;
+                newteam.Description = team.Description;
+
+                newteam.Id = Guid.NewGuid();
+                var members = new List<Models.UserModel>();
+                foreach (var member in team.Members)
+                {
+                    members.Add(users[member]);
+                }
+                newteam.Members = members.ToArray();
+
+                ADBackend.Instance.Teams.Add(newteam);
+                newTeams[team.Name] = newteam;
+            }
+            return newTeams;
+        }
+
+        private static Dictionary<string, Models.UserModel> UpdateUsers(string dir)
+        {
+            var users = Pre600Functions.LoadContent<Pre600UserModel>(dir);
+            var domains = new Dictionary<string, PrincipalContext>();
+            var newUsers = new Dictionary<string, Models.UserModel>();
+            foreach (var user in users)
+            {
+                var ou = user.Value;
+                var u = new Models.UserModel();
+                u.Email = ou.Email;
+                u.GivenName = ou.GivenName;
+                u.Surname = ou.Surname;
+                u.Username = ou.Name;
+                u.Id = Guid.NewGuid();
+
+                PrincipalContext dc;
+                var domain = u.Username.GetDomain();
+                if (!domains.TryGetValue(domain, out dc))
+                {
+                    dc = new PrincipalContext(ContextType.Domain, domain);
+                    domains[domain] = dc;
+                }
+
+                var domainuser = UserPrincipal.FindByIdentity(dc, u.Username);
+                if (domainuser != null && domainuser.Guid.HasValue)
+                {
+                    u.Id = domainuser.Guid.Value;
+                }
+
+                ADBackend.Instance.Users.Add(u);
+                newUsers[u.Username] = u;
+            }
+            return newUsers;
+        }
+    }
+}

--- a/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
+++ b/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Bonobo.Git.Server.Configuration;
+using Bonobo.Git.Server.Data.Update.ADBackendUpdate;
+using System;
 using System.Data.Entity.Infrastructure;
 using System.Diagnostics;
 using System.Linq;
@@ -9,7 +11,14 @@ namespace Bonobo.Git.Server.Data.Update
     {
         public void Run()
         {
-            UpdateDatabase();
+            if (AuthenticationSettings.MembershipService.ToLowerInvariant() == "activedirectory")
+            {
+                Pre600UpdateTo600.UpdateADBackend();
+            }
+            else
+            {
+                UpdateDatabase();
+            }
         }
 
         public void RunWithContext(BonoboGitServerContext context)

--- a/Bonobo.Git.Server/Helpers/PathEncoder.cs
+++ b/Bonobo.Git.Server/Helpers/PathEncoder.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Text;
+using System.Web.Hosting;
 
 namespace Bonobo.Git.Server.Helpers
 {
@@ -114,6 +116,11 @@ namespace Bonobo.Git.Server.Helpers
             }
             // Return decoded string
             return Encoding.UTF8.GetString(bytes.ToArray());
+        }
+
+        public static string GetRootPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : HostingEnvironment.MapPath(path);
         }
     }
 }


### PR DESCRIPTION
* Moved GetRootPath from ADBackendStore to PathEncoder to make it available to the update mechanism.

* ADBackend: Added function to create ADBackend instance that does not automatically update the storage. Added similar function to do automatic update.

* Added functions to update the ADBackend storage from pre 6.0.

* Use Guid ID for item filename in ADBackendStore, rather than hashing name (which might change)